### PR TITLE
Add app URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 "Proof of Grind" is a modern and feature-rich todo list application designed to help you track your tasks, stay organized, and share your accomplishments. It's more than just a simple todo list; it's a tool to visualize your progress and celebrate your hard work.
 
+Try it out here: [https://proof-of-grind-basic.vercel.app/](https://proof-of-grind-basic.vercel.app/)
+
 ## Features
 
 *   **User Authentication**: Secure user authentication powered by Supabase.


### PR DESCRIPTION
This change adds the live application URL (https://proof-of-grind-basic.vercel.app/) to the top of the README.md file. This allows users visiting the repository to easily find and try out the application.

Fixes #4

---
*PR created automatically by Jules for task [15218949113540855405](https://jules.google.com/task/15218949113540855405) started by @Shru*