### PR TITLE
fix: reliably persist default category deletions across page reloads

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ export default function App() {
   const [filterCategory, setFilterCategory] = useState("all");
   const [filterPriority, setFilterPriority] = useState("all");
   const [customCategories, setCustomCategories] = useState<string[]>([]);
+  const [defaultCategories, setDefaultCategories] = useState<string[]>(["Work", "Personal", "Shopping", "Health"]);
 
   // Check for share link in URL
   useEffect(() => {
@@ -241,12 +242,10 @@ export default function App() {
     toast.info("Filters cleared");
   };
   const deleteCategory = (categoryToDelete: string) => {
-  setCustomCategories(
-    customCategories.filter(
-      (category: string) => category !== categoryToDelete
-    )
-  );
-};
+    setDefaultCategories((prev) => prev.filter((c) => c !== categoryToDelete));
+    setCustomCategories((prev) => prev.filter((c) => c !== categoryToDelete));
+    toast.info(`Category "${categoryToDelete}" removed`);
+  };
 
 
   // Show share view if shareId is present
@@ -339,6 +338,7 @@ export default function App() {
             >
               <TodoInput
                 onAdd={addTodo}
+                defaultCategories={defaultCategories}
                 customCategories={customCategories}
                 onAddCategory={addCustomCategory}
                 onDeleteCategory={deleteCategory}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,8 @@ import { toast } from "sonner@2.0.3";
 import { checkAuthentication, logout, fetchTodos, saveTodos, fetchCategories, saveCategories } from "./utils/api";
 import logo from "./assets/logo.png";
 
+const DEFAULT_CATEGORIES = ["Work", "Personal", "Shopping", "Health"];
+
 export default function App() {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -25,7 +27,8 @@ export default function App() {
   const [filterCategory, setFilterCategory] = useState("all");
   const [filterPriority, setFilterPriority] = useState("all");
   const [customCategories, setCustomCategories] = useState<string[]>([]);
-  const [defaultCategories, setDefaultCategories] = useState<string[]>(["Work", "Personal", "Shopping", "Health"]);
+  const [defaultCategories, setDefaultCategories] = useState<string[]>(DEFAULT_CATEGORIES);
+  const [categoriesInitialized, setCategoriesInitialized] = useState(false);
 
   // Check for share link in URL
   useEffect(() => {
@@ -63,16 +66,14 @@ export default function App() {
 
   // Auto-save categories whenever they change (with debounce)
   useEffect(() => {
-    if (isAuthenticated && !isLoading && customCategories.length > 0) {
-      const timeoutId = setTimeout(() => {
-        saveCategories(customCategories).catch((error) => {
-          console.error("Error saving categories:", error);
-        });
-      }, 500);
-      
-      return () => clearTimeout(timeoutId);
-    }
-  }, [customCategories, isAuthenticated, isLoading]);
+    if (!isAuthenticated || !categoriesInitialized) return;
+    const timeoutId = setTimeout(() => {
+      saveCategories([...defaultCategories, ...customCategories]).catch((error) => {
+        console.error("Error saving categories:", error);
+      });
+    }, 500);
+    return () => clearTimeout(timeoutId);
+  }, [defaultCategories, customCategories, isAuthenticated, categoriesInitialized]);
 
   async function checkAuth() {
     try {
@@ -93,12 +94,25 @@ export default function App() {
         fetchCategories(),
       ]);
       setTodos(todosData || []);
-      setCustomCategories(categoriesData || []);
+      const fetched: string[] = categoriesData || [];
+      const isNewFormat = fetched.some((c) => DEFAULT_CATEGORIES.includes(c));
+      if (fetched.length === 0 || !isNewFormat) {
+        // New user or old-format data: show hardcoded defaults alongside any saved customs
+        setDefaultCategories(DEFAULT_CATEGORIES);
+        setCustomCategories(fetched);
+      } else {
+        // New format: entire list (defaults + customs) stored together
+        setDefaultCategories([]);
+        setCustomCategories(fetched);
+      }
+      setCategoriesInitialized(true);
     } catch (error) {
       console.error("Error loading data:", error);
       // Don't show error toast for initial load, just set empty arrays
       setTodos([]);
+      setDefaultCategories(DEFAULT_CATEGORIES);
       setCustomCategories([]);
+      setCategoriesInitialized(true);
     }
   }
 
@@ -107,14 +121,18 @@ export default function App() {
       await logout();
       setIsAuthenticated(false);
       setTodos([]);
+      setDefaultCategories(DEFAULT_CATEGORIES);
       setCustomCategories([]);
+      setCategoriesInitialized(false);
       toast.success("Logged out successfully");
     } catch (error) {
       console.error("Logout error:", error);
       // Still logout on frontend even if backend fails
       setIsAuthenticated(false);
       setTodos([]);
+      setDefaultCategories(DEFAULT_CATEGORIES);
       setCustomCategories([]);
+      setCategoriesInitialized(false);
       toast.success("Logged out");
     }
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,7 @@ export default function App() {
   useEffect(() => {
     if (!isAuthenticated || !categoriesInitialized) return;
     const timeoutId = setTimeout(() => {
-      saveCategories([...defaultCategories, ...customCategories]).catch((error) => {
+      saveCategories(["__v2", ...defaultCategories, ...customCategories]).catch((error) => {
         console.error("Error saving categories:", error);
       });
     }, 500);
@@ -95,14 +95,21 @@ export default function App() {
       ]);
       setTodos(todosData || []);
       const fetched: string[] = categoriesData || [];
-      const isNewFormat = fetched.some((c) => DEFAULT_CATEGORIES.includes(c));
-      if (fetched.length === 0 || !isNewFormat) {
-        // New user or old-format data: show hardcoded defaults alongside any saved customs
+      if (fetched[0] === "__v2") {
+        // Sentinel present: authoritative new format, load exactly what was saved
+        setDefaultCategories([]);
+        setCustomCategories(fetched.slice(1));
+      } else if (fetched.length === 0) {
+        // New user with no saved categories
         setDefaultCategories(DEFAULT_CATEGORIES);
+        setCustomCategories([]);
+      } else if (fetched.some((c) => DEFAULT_CATEGORIES.includes(c))) {
+        // Transitional new format (saved before sentinel was introduced)
+        setDefaultCategories([]);
         setCustomCategories(fetched);
       } else {
-        // New format: entire list (defaults + customs) stored together
-        setDefaultCategories([]);
+        // Old format: only custom categories were saved, prepend hardcoded defaults
+        setDefaultCategories(DEFAULT_CATEGORIES);
         setCustomCategories(fetched);
       }
       setCategoriesInitialized(true);
@@ -155,9 +162,12 @@ export default function App() {
   };
 
   const addCustomCategory = (category: string) => {
-    if (!customCategories.includes(category)) {
+    const allCategories = [...defaultCategories, ...customCategories];
+    if (!allCategories.includes(category)) {
       setCustomCategories([category, ...customCategories]);
       toast.success(`Category "${category}" added`);
+    } else {
+      toast.error(`Category "${category}" already exists`);
     }
   };
 

--- a/src/components/TodoInput.tsx
+++ b/src/components/TodoInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Plus } from "lucide-react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
@@ -44,6 +44,13 @@ export function TodoInput({
   const [dueDate, setDueDate] = useState("");
   const [showCategoryDialog, setShowCategoryDialog] = useState(false);
   const [newCategory, setNewCategory] = useState("");
+
+  useEffect(() => {
+    const allCategories = [...defaultCategories, ...customCategories];
+    if (allCategories.length > 0 && !allCategories.includes(category)) {
+      setCategory(allCategories[0]);
+    }
+  }, [defaultCategories, customCategories]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/TodoInput.tsx
+++ b/src/components/TodoInput.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Plus, X } from "lucide-react";
+import { Plus } from "lucide-react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import {
@@ -106,33 +106,21 @@ export function TodoInput({
             </SelectTrigger>
             <SelectContent>
               {defaultCategories.map((cat) => (
-                <SelectItem key={cat} value={cat} className="justify-between gap-2">
-                  <span>{cat}</span>
-                  <button
-                    type="button"
-                    onPointerDown={(event) => {
-                      event.preventDefault();
-                      onDeleteCategory(cat);
-                    }}
-                    className="ml-auto flex items-center text-red-400 hover:text-red-200"
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
+                <SelectItem
+                  key={cat}
+                  value={cat}
+                  onDelete={(e) => { e.preventDefault(); onDeleteCategory(cat); }}
+                >
+                  {cat}
                 </SelectItem>
               ))}
               {customCategories.map((cat) => (
-                <SelectItem key={cat} value={cat} className="justify-between gap-2">
-                  <span>{cat}</span>
-                  <button
-                    type="button"
-                    onPointerDown={(event) => {
-                      event.preventDefault();
-                      onDeleteCategory(cat);
-                    }}
-                    className="ml-auto flex items-center text-red-400 hover:text-red-200"
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
+                <SelectItem
+                  key={cat}
+                  value={cat}
+                  onDelete={(e) => { e.preventDefault(); onDeleteCategory(cat); }}
+                >
+                  {cat}
                 </SelectItem>
               ))}
               <SelectItem value="add_new" className="text-violet-400">

--- a/src/components/TodoInput.tsx
+++ b/src/components/TodoInput.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Plus } from "lucide-react";
+import { Plus, X } from "lucide-react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import {
@@ -113,9 +113,9 @@ export function TodoInput({
                       event.preventDefault();
                       onDeleteCategory(cat);
                     }}
-                    className="text-xs text-red-400 hover:text-red-200"
+                    className="ml-auto flex items-center text-red-400 hover:text-red-200"
                   >
-                    ×
+                    <X className="h-3 w-3" />
                   </button>
                 </SelectItem>
               ))}
@@ -128,9 +128,9 @@ export function TodoInput({
                       event.preventDefault();
                       onDeleteCategory(cat);
                     }}
-                    className="text-xs text-red-400 hover:text-red-200"
+                    className="ml-auto flex items-center text-red-400 hover:text-red-200"
                   >
-                    ×
+                    <X className="h-3 w-3" />
                   </button>
                 </SelectItem>
               ))}

--- a/src/components/TodoInput.tsx
+++ b/src/components/TodoInput.tsx
@@ -26,6 +26,7 @@ interface TodoInputProps {
     dueDate?: string;
   }) => void;
   customCategories: string[];
+  defaultCategories: string[];
   onAddCategory: (category: string) => void;
   onDeleteCategory: (category: string) => void;
 }
@@ -33,6 +34,7 @@ interface TodoInputProps {
 export function TodoInput({
   onAdd,
   customCategories,
+  defaultCategories,
   onAddCategory,
   onDeleteCategory,
 }: TodoInputProps) {
@@ -74,7 +76,6 @@ export function TodoInput({
     }
   };
 
-  const defaultCategories = ["Work", "Personal", "Shopping", "Health"];
 
   return (
     <Card className="p-4 bg-gray-900/90 backdrop-blur-sm border-2 border-gray-800 shadow-lg">

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -6,6 +6,7 @@ import {
   CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
+  XIcon,
 } from "lucide-react@0.487.0";
 
 import { cn } from "./utils";
@@ -105,8 +106,11 @@ function SelectLabel({
 function SelectItem({
   className,
   children,
+  onDelete,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+}: React.ComponentProps<typeof SelectPrimitive.Item> & {
+  onDelete?: (e: React.PointerEvent<HTMLButtonElement>) => void;
+}) {
   return (
     <SelectPrimitive.Item
       data-slot="select-item"
@@ -117,9 +121,23 @@ function SelectItem({
       {...props}
     >
       <span className="absolute right-2 flex size-3.5 items-center justify-center">
-        <SelectPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
-        </SelectPrimitive.ItemIndicator>
+        {onDelete ? (
+          <button
+            type="button"
+            onPointerDown={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onDelete(e);
+            }}
+            className="flex items-center text-red-400 hover:text-red-200 [&_svg]:pointer-events-auto cursor-pointer"
+          >
+            <XIcon className="size-3.5" />
+          </button>
+        ) : (
+          <SelectPrimitive.ItemIndicator>
+            <CheckIcon className="size-4" />
+          </SelectPrimitive.ItemIndicator>
+        )}
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
     </SelectPrimitive.Item>


### PR DESCRIPTION
## Summary
- Fixed persistence bug where deleted default categories reappeared after page reload
- Fixed selected category not resetting when the chosen category is deleted
- Fixed duplicate category names being allowed

Closes #11
